### PR TITLE
Use stable varnish 6.0

### DIFF
--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -3,7 +3,7 @@ version: '3.6'
 services:
   varnish:
     container_name: ddev-${DDEV_SITENAME}-varnish
-    image: varnish:7.1
+    image: varnish:6.0
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
I had used varnish 7.1, but 6.0 is "stable" and has both arm64 and amd64 images.