### PR TITLE
Handle multiple hostnames/fqdns, fixes #4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: Environment setup
       run: |
         brew install bats-core mkcert

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,8 +68,7 @@ jobs:
 
     - name: Download docker images
       run: | 
-        mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-        docker pull memcached:1.6 >/dev/null
+        mkdir junk && pushd junk && ddev config --omit-containers=dba,db && ddev debug download-images >/dev/null
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3
       with:

--- a/README.md
+++ b/README.md
@@ -9,19 +9,20 @@ This repository allows you to quickly install the Varnish reverse proxy into a [
 1. `ddev get drud/ddev-varnish`
 2. `ddev restart`
 
-## Explanation 
+## Explanation
 
 The Varnish service inserts itself between ddev-router and the web container, so that calls
 to the web container are routed through Varnish first. The [docker-compose.varnish.yaml](https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/varnish/docker-compose.varnish.yml)
-replaces the ```VIRTUAL_HOST``` variable of the web container with a subdomain of
-the website URL (see below) and uses the default domain as its own host name.
+installs Varnish and uses the default domain as its own host name. A docker-compose.varnish-extras.yaml file is generated on install which replaces the ```VIRTUAL_HOST``` variable of the web container with a sub-domain of the website URL. For example, mysite.ddev.site, would be accessible via Varnish on mysite.ddev.site and directly on novarnish.mysite.ddev.site.
+
+If you use a project_tld other than ddev.site or additional_fqdns DDEV will help add hosts entries for the hostnames automagically; however, you'll need to add entries for the novarnish.* sub-domains yourself, e.g. `ddev hostname novarnish.testaddfqdn.random.tld 127.0.0.1`.
+
+Run `ddev get drud/ddev-varnish` after changes to name, additional_hostnames, additional_fqdns, or project_tld in .ddev/config.yml so that .ddev/docker-compose.varnish-extras.yaml is regenerated.
 
 ## Additional Configuration
-* You may want to edit the `.ddev/varnish/default.vcl` to meet your needs.
 
+* You may want to edit the `.ddev/varnish/default.vcl` to meet your needs. Remember to remove '#ddev-generated' from the file if you want your changes to the file preserved.
 
 **Maintained by [@rfay](https://github.com/rfay)**
 
 **Based on the original [ddev-contrib recipe](https://github.com/drud/ddev-contrib/tree/master/docker-compose-services/varnish) pioneered by [rikwillems](https://github.com/rikwillems)**
-
-

--- a/docker-compose.varnish.yaml
+++ b/docker-compose.varnish.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 #ddev-generated
 services:
   varnish:
@@ -25,9 +24,3 @@ services:
       - ".:/mnt/ddev_config"
     depends_on:
       - web
-
-  # This is the second half of the trick that puts varnish "in front of" the web
-  # container, just by switching the names.
-  web:
-    environment:
-      - VIRTUAL_HOST=novarnish.$DDEV_HOSTNAME

--- a/install.yaml
+++ b/install.yaml
@@ -5,3 +5,24 @@ project_files:
 - docker-compose.varnish.yaml
 - varnish
 
+post_install_actions:
+  - |
+    #ddev-nodisplay
+    if [ -f .ddev/docker-compose.varnish-extras.yaml ] && ! grep '#ddev-generated' .ddev/config.varnish-extras.yaml; then
+      echo "Existing docker-compose.varnish-extras.yaml does not have #ddev-generated, so can't be updated"
+    exit 2
+    fi
+  - |
+    #ddev-nodisplay
+    cat  <<-END >docker-compose.varnish-extras.yaml
+    #ddev-generated
+    # This is the second half of the trick that puts varnish "in front of" the web
+    # container, just by switching the names.
+    services:
+      web:
+        environment:
+        - VIRTUAL_HOST=novarnish.{{ join ",novarnish." (concat .configyaml.additional_hostnames .configyaml.additional_fqdns)}}
+    END
+
+yaml_read_files:
+  configyaml: .ddev/config.yaml

--- a/install.yaml
+++ b/install.yaml
@@ -18,11 +18,20 @@ post_install_actions:
     #ddev-generated
     # This is the second half of the trick that puts varnish "in front of" the web
     # container, just by switching the names.
+    {{ $project_tld := "ddev.site" }}
+    {{ if .DdevGlobalConfig.project_tld }}{{ $project_tld = .DdevGlobalConfig.project_tld }}{{ end }}
+    {{ if .DdevProjectConfig.project_tld }}{{ $project_tld = .DdevProjectConfig.project_tld }} {{ end }}
+    {{ $novarnish_hostnames := print "novarnish." .DdevProjectConfig.name "." $project_tld  }}
+    {{ $sep := print "." $project_tld ",novarnish." }}
+    {{ if .DdevProjectConfig.additional_hostnames }}
+    {{ $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." (.DdevProjectConfig.additional_hostnames | join $sep) "." $project_tld }}
+    {{ end }}
+    {{ if .DdevProjectConfig.additional_fqdns }}
+    {{ $novarnish_hostnames = print $novarnish_hostnames "," "novarnish." ( .DdevProjectConfig.additional_fqdns | join ",novarnish." )   }}
+    {{ end }}
     services:
       web:
         environment:
-        - VIRTUAL_HOST=novarnish.{{ join ",novarnish." (append (concat .configyaml.additional_hostnames .configyaml.additional_fqdns) .configyaml.name ) }}
-    END
+        - VIRTUAL_HOST={{ $novarnish_hostnames }}
 
-yaml_read_files:
-  configyaml: .ddev/config.yaml
+    END

--- a/install.yaml
+++ b/install.yaml
@@ -21,7 +21,7 @@ post_install_actions:
     services:
       web:
         environment:
-        - VIRTUAL_HOST=novarnish.{{ join ",novarnish." (concat .configyaml.additional_hostnames .configyaml.additional_fqdns)}}
+        - VIRTUAL_HOST=novarnish.{{ join ",novarnish." (append (concat .configyaml.additional_hostnames .configyaml.additional_fqdns) .configyaml.name ) }}
     END
 
 yaml_read_files:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -32,6 +32,10 @@ teardown() {
     echo "# test $url for phpinfo content" >&3
     curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
   done
+  for url in http://novarnish.${PROJNAME}.ddev.site/ http://novarnish.extrahostname.ddev.site/ http://novarnish.extrafqdn.ddev.site/ https://novarnish.${PROJNAME}.ddev.site/ https://novarnish.extrahostname.ddev.site/ https://novarnish.extrafqdn.ddev.site/ ; do
+    echo "# test $url for phpinfo content" >&3
+    curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
+  done
 }
 
 # Re-enable install from release after this goes in. It can't work right now because of the issue we're working on.
@@ -41,6 +45,15 @@ teardown() {
 #  echo "# ddev get drud/ddev-varnish with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
 #  ddev get drud/ddev-varnish >/dev/null
 #  ddev restart >/dev/null 2>&1
-#  (curl -sI http://${PROJNAME}.ddev.site/ | grep "Via:.*varnish" >/dev/null) || (echo "#  varnish headers not shown" && exit 1)
-#  (curl -s http://${PROJNAME}.ddev.site/ | grep "allow_url_fopen" >/dev/null) || (echo "# phpinfo information not shown in curl" && exit 1)
+#  for url in http://${PROJNAME}.ddev.site/ http://extrahostname.ddev.site/ http://extrafqdn.ddev.site/ https://${PROJNAME}.ddev.site/ https://extrahostname.ddev.site/ https://extrafqdn.ddev.site/ ; do
+#    # It's "Via:" with http and "via:" with https. Tell me why.
+#    echo "# test $url for via:.*varnish header" >&3
+#    curl -sI $url | grep -i "Via:.*varnish" >/dev/null || (echo "# varnish headers not shown for $url"  >&3 && exit 1);
+#    echo "# test $url for phpinfo content" >&3
+#    curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
+#  done
+#  for url in http://novarnish.${PROJNAME}.ddev.site/ http://novarnish.extrahostname.ddev.site/ http://novarnish.extrafqdn.ddev.site/ https://novarnish.${PROJNAME}.ddev.site/ https://novarnish.extrahostname.ddev.site/ https://novarnish.extrafqdn.ddev.site/ ; do
+#    echo "# test $url for phpinfo content" >&3
+#    curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
+#  done
 #}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -5,17 +5,17 @@ setup() {
   mkdir -p $TESTDIR
   export PROJNAME=test-varnish
   export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} || true
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME}
+  ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --omit-containers=dba,db >/dev/null
   printf "<?php\nphpinfo();\n" >index.php
-  ddev start
+  ddev start >/dev/null
 }
 
 teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || (printf "unable to cd to ${TESTDIR}\n" && exit 1)
-  ddev delete -Oy ${PROJNAME}
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
@@ -23,10 +23,13 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
-  ddev restart
-  (curl -sI http://${PROJNAME}.ddev.site/ | grep "Via:.*varnish") || (echo "#  varnish headers not shown" && exit 1)
-  (curl -s http://${PROJNAME}.ddev.site/ | grep "allow_url_fopen") || (echo "# phpinfo information not shown in curl" && exit 1)
+  ddev get ${DIR} >/dev/null
+  ddev restart >/dev/null 2>&1
+  for url in http://${PROJNAME}.ddev.site/ http://extrahostname.ddev.site/ https://${PROJNAME}.ddev.site/ https://extrahostname.ddev.site/; do
+    # It's "Via:" with http and "via:" with https. Tell me why.
+    curl -sI $url | grep -i "Via:.*varnish" >/dev/null || (echo "# varnish headers not shown for $url"  >&3 && exit 1);
+    curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
+  done
 }
 
 @test "install from release" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -7,7 +7,7 @@ setup() {
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --omit-containers=dba,db >/dev/null
+  ddev config --project-name=${PROJNAME} --additional-hostnames=extrahostname --additional-fqdns=extrafqdn.ddev.site --omit-containers=dba,db >/dev/null
   printf "<?php\nphpinfo();\n" >index.php
   ddev start >/dev/null
 }
@@ -25,19 +25,20 @@ teardown() {
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR} >/dev/null
   ddev restart >/dev/null 2>&1
-  for url in http://${PROJNAME}.ddev.site/ http://extrahostname.ddev.site/ https://${PROJNAME}.ddev.site/ https://extrahostname.ddev.site/; do
+  for url in http://${PROJNAME}.ddev.site/ http://extrahostname.ddev.site/ http://extrafqdn.ddev.site/ https://${PROJNAME}.ddev.site/ https://extrahostname.ddev.site/ https://extrafqdn.ddev.site/ ; do
     # It's "Via:" with http and "via:" with https. Tell me why.
     curl -sI $url | grep -i "Via:.*varnish" >/dev/null || (echo "# varnish headers not shown for $url"  >&3 && exit 1);
     curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
   done
 }
 
-@test "install from release" {
-  set -eu -o pipefail
-  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get drud/ddev-varnish with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get drud/ddev-varnish
-  ddev restart
-  (curl -sI http://${PROJNAME}.ddev.site/ | grep "Via:.*varnish") || (echo "#  varnish headers not shown" && exit 1)
-  (curl -s http://${PROJNAME}.ddev.site/ | grep "allow_url_fopen") || (echo "# phpinfo information not shown in curl" && exit 1)
-}
+# Re-enable install from release after this goes in. It can't work right now because of the issue we're working on.
+#@test "install from release" {
+#  set -eu -o pipefail
+#  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+#  echo "# ddev get drud/ddev-varnish with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+#  ddev get drud/ddev-varnish >/dev/null
+#  ddev restart >/dev/null 2>&1
+#  (curl -sI http://${PROJNAME}.ddev.site/ | grep "Via:.*varnish" >/dev/null) || (echo "#  varnish headers not shown" && exit 1)
+#  (curl -s http://${PROJNAME}.ddev.site/ | grep "allow_url_fopen" >/dev/null) || (echo "# phpinfo information not shown in curl" && exit 1)
+#}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -27,7 +27,9 @@ teardown() {
   ddev restart >/dev/null 2>&1
   for url in http://${PROJNAME}.ddev.site/ http://extrahostname.ddev.site/ http://extrafqdn.ddev.site/ https://${PROJNAME}.ddev.site/ https://extrahostname.ddev.site/ https://extrafqdn.ddev.site/ ; do
     # It's "Via:" with http and "via:" with https. Tell me why.
+    echo "# test $url for via:.*varnish header" >&3
     curl -sI $url | grep -i "Via:.*varnish" >/dev/null || (echo "# varnish headers not shown for $url"  >&3 && exit 1);
+    echo "# test $url for phpinfo content" >&3
     curl -s $url | grep "allow_url_fopen" >/dev/null || (echo "# phpinfo information not shown in curl for $url" >&3 && exit 1);
   done
 }


### PR DESCRIPTION
For 
* #4 

This tries to process additional_hostnames and additional_fqdns to make varnish still work with those in use.

Adds test for additional_hostnames and additional_fqdns

This can be tested with
```
ddev get https://github.com/rfay/ddev-varnish/tarball/20221029_varnish_multiple_hostnames
```