### PR TITLE
feat: add helper commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ If you use a project_tld other than ddev.site or additional_fqdns DDEV will help
 
 Run `ddev get drud/ddev-varnish` after changes to name, additional_hostnames, additional_fqdns, or project_tld in .ddev/config.yml so that .ddev/docker-compose.varnish-extras.yaml is regenerated.
 
+## Helper commands
+
+This addon also providers several helper commands. These helpers allow developers to run Varnish commands from the host, however, the commands are actually run inside the Varnish container.
+
+| Command | Description |
+| --- | --- |
+| `ddev varnishd` | Varnish-cli |
+| `ddev varnishhist` | Display Varnish request histogram |
+| `ddev varnishlog` | Display Varnish logs |
+| `ddev varnishncsa` | Display Varnish logs in Apache / NCSA combined log format |
+| `ddev varnishstat` | Display Varnish Cache statistics |
+| `ddev varnishtest` | Test program for Varnish |
+| `ddev varnishtop` | Display Varnish log entry ranking |
+
+See [The Varnish Reference Manual](https://varnish-cache.org/docs/6.5/reference/index.html) for more information about the commands, their flags, and their arguments.
+
 ## Additional Configuration
 
 * You may want to edit the `.ddev/varnish/default.vcl` to meet your needs. Remember to remove '#ddev-generated' from the file if you want your changes to the file preserved.

--- a/commands/varnish/varnishd
+++ b/commands/varnish/varnishd
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Varnish-cli
+## Usage: varnishd
+## Example: "ddev varnishd -d" for CLI in foreground.
+## Example: "ddev varnishd -T" to connect with varnishadm or telnet.
+## Example: "ddev varnishd -M" to connect back to a listening service pushing the CLI to that service.
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishd "$@"

--- a/commands/varnish/varnishd
+++ b/commands/varnish/varnishd
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Varnish-cli
-## Usage: varnishd
+## Usage: varnishd [flags] [args]
 ## Example: "ddev varnishd -d" for CLI in foreground.
 ## Example: "ddev varnishd -T" to connect with varnishadm or telnet.
 ## Example: "ddev varnishd -M" to connect back to a listening service pushing the CLI to that service.

--- a/commands/varnish/varnishhist
+++ b/commands/varnish/varnishhist
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish request histogram
+## Usage: varnishhist
+## Example: "ddev varnishhist"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishhist "$@"

--- a/commands/varnish/varnishhist
+++ b/commands/varnish/varnishhist
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Display Varnish request histogram
-## Usage: varnishhist
+## Usage: varnishhist [flags] [args]
 ## Example: "ddev varnishhist"
 
 # This example runs inside the varnish container.

--- a/commands/varnish/varnishlog
+++ b/commands/varnish/varnishlog
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Display Varnish logs
-## Usage: varnishlog
+## Usage: varnishlog [flags] [args]
 ## Example: "ddev varnishlog"
 
 # This example runs inside the varnish container.

--- a/commands/varnish/varnishlog
+++ b/commands/varnish/varnishlog
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish logs
+## Usage: varnishlog
+## Example: "ddev varnishlog"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishlog "$@"

--- a/commands/varnish/varnishncsa
+++ b/commands/varnish/varnishncsa
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish logs in Apache / NCSA combined log format
+## Usage: varnishncsa
+## Example: "ddev varnishncsa"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishncsa "$@"

--- a/commands/varnish/varnishncsa
+++ b/commands/varnish/varnishncsa
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Display Varnish logs in Apache / NCSA combined log format
-## Usage: varnishncsa
+## Usage: varnishncsa [flags] [args]
 ## Example: "ddev varnishncsa"
 
 # This example runs inside the varnish container.

--- a/commands/varnish/varnishstat
+++ b/commands/varnish/varnishstat
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish Cache statistics
+## Usage: varnishstat
+## Example: "ddev varnishstat"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishstat "$@"

--- a/commands/varnish/varnishstat
+++ b/commands/varnish/varnishstat
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Display Varnish Cache statistics
-## Usage: varnishstat
+## Usage: varnishstat [flags] [args]
 ## Example: "ddev varnishstat"
 
 # This example runs inside the varnish container.

--- a/commands/varnish/varnishtest
+++ b/commands/varnish/varnishtest
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Test program for Varnish
-## Usage: varnishtest
+## Usage: varnishtest [flags] [args]
 ## Example: "ddev varnishtest"
 
 # This example runs inside the varnish container.

--- a/commands/varnish/varnishtest
+++ b/commands/varnish/varnishtest
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Test program for Varnish
+## Usage: varnishtest
+## Example: "ddev varnishtest"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishtest "$@"

--- a/commands/varnish/varnishtop
+++ b/commands/varnish/varnishtop
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Display Varnish log entry ranking
-## Usage: varnishtop
+## Usage: varnishtop [flags] [args]
 ## Example: "ddev varnishtop"
 
 # This example runs inside the varnish container.

--- a/commands/varnish/varnishtop
+++ b/commands/varnish/varnishtop
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish log entry ranking
+## Usage: varnishtop
+## Example: "ddev varnishtop"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishtop "$@"

--- a/install.yaml
+++ b/install.yaml
@@ -4,6 +4,7 @@ name: varnish
 project_files:
 - docker-compose.varnish.yaml
 - varnish
+- commands/varnish
 
 post_install_actions:
   - |


### PR DESCRIPTION
This PR adds helper commands for interacting with Varnish.

All commands are designed to:

- run in the Varnish container
- pass through additional parameters from original command.

Commands were sourced from https://varnish-cache.org/docs/6.5/reference/index.html .